### PR TITLE
Allow main area widgets to receive focus again.

### DIFF
--- a/packages/apputils/src/mainareawidget.ts
+++ b/packages/apputils/src/mainareawidget.ts
@@ -67,6 +67,7 @@ export class MainAreaWidget<T extends Widget = Widget>
     if (!content.id) {
       content.id = DOMUtils.createDomID();
     }
+    content.node.tabIndex = -1;
 
     this._updateTitle();
     content.title.changed.connect(this._updateTitle, this);


### PR DESCRIPTION
Allow main area widgets to receive focus again, but exclude from keyboard navigation.
